### PR TITLE
Adding bin/install, bin/release and updating bin/test

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,9 +172,9 @@ api.get_asset_size(asset_url: URL)
 
 
 ## Development
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests.
+After checking out the repo, run `bin/setup` to install dependencies. Then, run bin/test` to run the tests.
 
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags.
+To install this gem onto your local machine, run `bin/install`. To release a new version, update the version number in `version.rb`, and then run `bin/release`, which will create a git tag for the version, push git commits and tags.
 
 
 ## Contributing

--- a/bin/install
+++ b/bin/install
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+bundle exec rake install

--- a/bin/release
+++ b/bin/release
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+bundle exec rake release

--- a/bin/test
+++ b/bin/test
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-rake test
+bundle exec rake test


### PR DESCRIPTION
While addressing the following failure after running `bin/test` I noticed that we can add `install` and `release` scripts as well. Failure details:

```
An error occurred while loading spec_helper. - Did you mean?
                    rspec ./spec/spec_helper.rb

                    Failure/Error: require 'bundler/setup'

                    Gem::LoadError:
                      You have already activated excon 0.70.0, but your Gemfile requires excon 0.68.0. Prepending `bundle exec` to your command  may solve this.
# ./spec/spec_helper.rb:2:in `<top (required)>'
                      No examples found.
                      No examples found.


                      Finished in 0.00003 seconds (files took 0.5343 seconds to load)
                      0 examples, 0 failures, 1 error occurred outside of examples

                      Finished in 0.00003 seconds (files took 0.5343 seconds to load)
                      0 examples, 0 failures, 1 error occurred outside of examples
```