### PR TITLE
Patch to latest excon version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,7 +20,7 @@ GEM
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     dotenv (2.7.5)
-    excon (0.68.0)
+    excon (0.71.1)
     http-accept (1.7.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)

--- a/nexus_api.gemspec
+++ b/nexus_api.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.authors       = ['Francis Levesque', 'Gavin Miller']
   spec.email         = ['francis.d.levesque@gmail.com', 'me@gavinmiller.io']
 
-  spec.summary       = %q{nexus_api: provides access to Nexus through ruby!}
+  spec.summary       = %q{Provides API access to Sonatype Nexus through ruby!}
   spec.homepage      = "https://github.com/Cisco-AMP/nexus_api"
   spec.license       = 'MIT'
 


### PR DESCRIPTION
- Use the latest `excon` gem version to avoid a [low severity vulnerability](https://github.com/excon/excon/security/advisories/GHSA-q58g-455p-8vw9)